### PR TITLE
Support loading topology from directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 A simple network path simulator. Topology is described in YAML format and the
 `simulate` command shows how a packet would travel from source to destination.
 
+Topology may be provided as a single file or as a directory containing
+multiple `*.yaml` files. When a directory is supplied, all YAML files in that
+directory are merged.
+
 ```
 python -m netbagger.cli simulate topology.yaml 192.0.2.1 198.51.100.1
 ```

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from netbagger.topology import load_topology
+
+
+def test_load_single_file(tmp_path):
+    cfg = tmp_path / "single.yaml"
+    cfg.write_text(
+        """
+        nodes:
+          R1:
+            interfaces:
+              - name: net1
+                network: 10.0.0.1/24
+        """
+    )
+    nodes = load_topology(str(cfg))
+    assert set(nodes) == {"R1"}
+    assert str(nodes["R1"].interfaces[0].network) == "10.0.0.0/24"
+
+
+def test_load_directory(tmp_path):
+    d = tmp_path
+    (d / "a.yaml").write_text(
+        """
+        nodes:
+          A:
+            interfaces:
+              - name: net1
+                network: 10.0.0.1/24
+        """
+    )
+    (d / "b.yaml").write_text(
+        """
+        nodes:
+          B:
+            interfaces:
+              - name: net2
+                network: 10.0.1.1/24
+        """
+    )
+    nodes = load_topology(str(d))
+    assert set(nodes) == {"A", "B"}
+


### PR DESCRIPTION
## Summary
- allow `load_topology` to merge multiple YAML files from a directory
- clarify README that directories containing topology YAML files are supported
- add tests for loading single files and directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c62a32d688324b1b53dd3421dc58e