### PR TITLE
Support shared subnets across nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@ Topology may be provided as a single file or as a directory containing
 multiple `*.yaml` files. When a directory is supplied, all YAML files in that
 directory are merged.
 
+Multiple nodes may use addresses from the same network. Only partially
+overlapping prefixes (for example `10.0.0.0/24` and `10.0.0.0/25`) are
+disallowed and produce a `Network overlap` error during loading.
+
+Valid example with two nodes on a shared subnet:
+
+```yaml
+nodes:
+  R1:
+    interfaces:
+      - name: net1
+        network: 10.0.0.1/24
+  R2:
+    interfaces:
+      - name: net1
+        network: 10.0.0.2/24
+```
+
 ## Installation
 
 Install dependencies from `requirements.txt`:

--- a/netbagger/model.py
+++ b/netbagger/model.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, field
-from ipaddress import IPv4Network
+from ipaddress import IPv4Interface, IPv4Network
 from typing import List, Optional
 
 @dataclass
 class Interface:
     name: str
-    network: IPv4Network
+    ip: IPv4Interface
 
 @dataclass
 class Route:

--- a/netbagger/simulator.py
+++ b/netbagger/simulator.py
@@ -24,7 +24,7 @@ def find_node_for_ip(nodes: Dict[str, Node], ip: str) -> Node:
     found = None
     for node in nodes.values():
         for iface in node.interfaces:
-            if ip in iface.network:
+            if ip == iface.ip.ip:
                 if found:
                     raise ValueError(f"IP {ip} is present on multiple nodes")
                 found = node
@@ -55,7 +55,7 @@ def simulate(nodes: Dict[str, Node], src_ip: str, dst_ip: str, ecmp: bool = Fals
     for _ in range(max_steps):
         # local delivery check
         for iface in current.interfaces:
-            if dst_ip_obj in iface.network:
+            if dst_ip_obj in iface.ip.network:
                 steps.append(Step(current.name, f"deliver to {dst_ip}"))
                 return Result.DELIVERED, steps
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -20,7 +20,7 @@ def test_load_single_file(tmp_path):
     )
     nodes = load_topology(str(cfg))
     assert set(nodes) == {"R1"}
-    assert str(nodes["R1"].interfaces[0].network) == "10.0.0.0/24"
+    assert str(nodes["R1"].interfaces[0].ip.network) == "10.0.0.0/24"
 
 
 def test_load_directory(tmp_path):
@@ -122,4 +122,44 @@ def test_gateway_on_same_network(tmp_path):
 
     nodes = topology.load_topology(str(cfg))
     assert set(nodes) == {"R1"}
+
+
+def test_hosts_can_share_network(tmp_path):
+    cfg = tmp_path / "topo.yaml"
+    cfg.write_text(
+        """
+        nodes:
+          R1:
+            interfaces:
+              - name: net1
+                network: 10.0.0.1/24
+          R2:
+            interfaces:
+              - name: net1
+                network: 10.0.0.2/24
+        """
+    )
+
+    nodes = load_topology(str(cfg))
+    assert set(nodes) == {"R1", "R2"}
+
+
+def test_partial_overlap_error(tmp_path):
+    cfg = tmp_path / "topo.yaml"
+    cfg.write_text(
+        """
+        nodes:
+          R1:
+            interfaces:
+              - name: net1
+                network: 10.0.0.1/24
+          R2:
+            interfaces:
+              - name: net1
+                network: 10.0.0.128/25
+        """
+    )
+
+    with pytest.raises(ValueError):
+        load_topology(str(cfg))
 


### PR DESCRIPTION
## Summary
- allow interface addresses to repeat across nodes by storing full IPv4Interface objects
- reject only partially overlapping networks
- update simulator and loader for new model
- document shared subnet support
- add tests for duplicate prefixes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687dd32c67708324b9de7283eba5df16