### PR TITLE
Add topology visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,13 @@ python -m netbagger.cli simulate example-topology/r1.yaml 192.0.2.1 198.51.100.1
 python -m netbagger.cli simulate example-topology/ 192.0.2.1 198.51.100.1
 ```
 
+### Visualizing a topology
+
+Generate a simple SVG diagram for a topology file or directory:
+
+```
+python -m netbagger.cli visualize example-topology/ -o topo.svg
+```
+
+The resulting `topo.svg` can be viewed in any web browser.
+

--- a/netbagger/cli.py
+++ b/netbagger/cli.py
@@ -13,6 +13,10 @@ def main():
     sim.add_argument("dst", help="destination IP")
     sim.add_argument("--ecmp", action="store_true", help="show all ECMP branches")
 
+    vis = sub.add_parser("visualize", help="render topology to SVG")
+    vis.add_argument("topology", help="topology YAML file or directory")
+    vis.add_argument("--output", "-o", default="topology.svg", help="output SVG file")
+
     args = parser.parse_args()
 
     if args.cmd == "simulate":
@@ -21,6 +25,11 @@ def main():
         for s in steps:
             print(s)
         print(res)
+    elif args.cmd == "visualize":
+        nodes = load_topology(args.topology)
+        from .visualize import visualize
+        path = visualize(nodes, args.output)
+        print(path)
     else:
         parser.print_help()
 

--- a/netbagger/visualize.py
+++ b/netbagger/visualize.py
@@ -1,0 +1,67 @@
+"""Simple SVG network visualizer."""
+from math import cos, sin, pi
+from typing import Dict, Tuple, Iterable
+
+from .model import Node
+
+
+def _edges(nodes: Dict[str, Node]) -> Iterable[Tuple[str, str]]:
+    seen = set()
+    names = list(nodes)
+    for i, a in enumerate(names):
+        na = nodes[a]
+        for b in names[i + 1:]:
+            nb = nodes[b]
+            for ia in na.interfaces:
+                for ib in nb.interfaces:
+                    if ia.ip.network == ib.ip.network:
+                        e = tuple(sorted((a, b)))
+                        if e not in seen:
+                            seen.add(e)
+                            yield e
+                            break
+    from .simulator import find_node_for_ip
+    for name, node in nodes.items():
+        for r in node.routes:
+            if r.via:
+                n2 = find_node_for_ip(nodes, r.via)
+                if n2:
+                    e = tuple(sorted((name, n2.name)))
+                    if e not in seen:
+                        seen.add(e)
+                        yield e
+
+
+def visualize(nodes: Dict[str, Node], out_file: str = "topology.svg") -> str:
+    """Generate a very simple SVG network graph."""
+    radius = 120
+    cx = cy = radius + 20
+    width = height = (radius + 20) * 2
+
+    names = sorted(nodes)
+    positions = {}
+    for idx, name in enumerate(names):
+        angle = 2 * pi * idx / len(names)
+        x = cx + radius * cos(angle)
+        y = cy + radius * sin(angle)
+        positions[name] = (x, y)
+
+    lines = [f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">']
+    for a, b in _edges(nodes):
+        x1, y1 = positions[a]
+        x2, y2 = positions[b]
+        lines.append(
+            f'<line x1="{x1:.1f}" y1="{y1:.1f}" x2="{x2:.1f}" y2="{y2:.1f}" stroke="black" />'
+        )
+    for name, (x, y) in positions.items():
+        lines.append(
+            f'<circle cx="{x:.1f}" cy="{y:.1f}" r="18" fill="lightgray" stroke="black" />'
+        )
+        lines.append(
+            f'<text x="{x:.1f}" y="{y:.1f}" font-size="12" text-anchor="middle" dominant-baseline="middle">{name}</text>'
+        )
+    lines.append('</svg>')
+
+    with open(out_file, 'w') as f:
+        f.write('\n'.join(lines))
+    return out_file

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from ipaddress import ip_interface
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from netbagger.model import Node, Interface
+from netbagger.visualize import visualize
+
+
+def test_visualize_creates_file(tmp_path):
+    nodes = {
+        'A': Node('A', [Interface('net1', ip_interface('10.0.0.1/24'))]),
+        'B': Node('B', [Interface('net1', ip_interface('10.0.0.2/24'))]),
+    }
+    out = tmp_path / 'g.svg'
+    visualize(nodes, str(out))
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add a new `visualize` command to generate an SVG diagram for a topology
- implement simple SVG drawing logic
- document the new command
- test that the SVG visualizer creates a file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6425ba0c8324ace035e10abf7bb6